### PR TITLE
Switch to dockerhub

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,13 @@ platform:
     arch: arm
 
 steps:
+  - name: rego:test
+    image: golang:1.17-stretch
+    commands:
+      - go install github.com/open-policy-agent/opa@v0.37.2
+      - opa test -v internal/policy/rego/
+      - opa test -v internal/policy/testdata/
+
   - name: golang:test
     image: golang:1.17-stretch
     commands:
@@ -19,15 +26,6 @@ steps:
     commands:
       - go test -v -coverprofile cover.out ./...
       - go tool cover -func cover.out
-    depends_on:
-      - golang:test
-
-  - name: rego:test
-    image: golang:1.17-stretch
-    commands:
-      - go install github.com/open-policy-agent/opa@v0.36.1
-      - opa test -v internal/policy/rego/
-      - opa test -v internal/policy/testdata/
 
   - name: react:test
     image: node:17.3-stretch
@@ -42,8 +40,6 @@ steps:
       - cd ui
       - npm install
       - npm run build
-    depends_on:
-      - react:test
 
 ---
 kind: pipeline
@@ -154,6 +150,6 @@ steps:
         **Message:** {{commit.message}}
 ---
 kind: signature
-hmac: 164f7269484314559278e3f35938ef3228acd90bac168a8c193035228577a1c6
+hmac: e1e5ff2db9b69a3b2f51b34a50795cb4c844d9173185dffbba71f64eef5f5c71
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -61,10 +61,18 @@ steps:
   - name: docker:staging
     image: docker-registry.pikube.dev:31443/drone-genuinetools-img
     settings:
-      registry: docker-registry-service.docker-registry:5000
-      repo: dndmachine-go
-      tags: ${DRONE_BRANCH},unstable
-      insecure_registry: true
+      repo: cromrots/dndmachine
+      tags: unstable
+      cache_from: cromrots/dndmachine:cache
+      cache_to: cromrots/dndmachine:cache
+      password:
+        from_secret: docker_pwd
+      username:
+        from_secret: docker_user
+    resources:
+      requests:
+        cpu: 1500
+        memory: 750MiB
 
 ---
 kind: pipeline
@@ -86,10 +94,18 @@ steps:
   - name: docker:staging
     image: docker-registry.pikube.dev:31443/drone-genuinetools-img
     settings:
-      registry: docker-registry-service.docker-registry:5000
-      repo: dndmachine-go
+      repo: cromrots/dndmachine
       auto_tag: true
-      insecure_registry: true
+      cache_from: cromrots/dndmachine:cache
+      cache_to: cromrots/dndmachine:cache
+      password:
+        from_secret: docker_pwd
+      username:
+        from_secret: docker_user
+    resources:
+      requests:
+        cpu: 1500
+        memory: 750MiB
 
 ---
 kind: pipeline
@@ -138,6 +154,6 @@ steps:
         **Message:** {{commit.message}}
 ---
 kind: signature
-hmac: ac4a7e71a9c450f57e9ee98d9146b93a32e60be34341600c53550c291a63ff08
+hmac: 164f7269484314559278e3f35938ef3228acd90bac168a8c193035228577a1c6
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -65,10 +65,6 @@ steps:
         from_secret: docker_pwd
       username:
         from_secret: docker_user
-    resources:
-      requests:
-        cpu: 1500
-        memory: 750MiB
 
 ---
 kind: pipeline
@@ -98,10 +94,6 @@ steps:
         from_secret: docker_pwd
       username:
         from_secret: docker_user
-    resources:
-      requests:
-        cpu: 1500
-        memory: 750MiB
 
 ---
 kind: pipeline
@@ -150,6 +142,6 @@ steps:
         **Message:** {{commit.message}}
 ---
 kind: signature
-hmac: e1e5ff2db9b69a3b2f51b34a50795cb4c844d9173185dffbba71f64eef5f5c71
+hmac: dad75941d56fbd698df5c838ead0d2012706e4347e520306af86953e9938e05e
 
 ...


### PR DESCRIPTION
docker:
* publish images to the public docker.io hub as `cromrots/dndmachine`, instead of the private registry.
* leverage the usage of a multi-stage cache image to speed up future builds.
* switch to the public `cromrots/opa` image to build the rego wasm bundle; avoids having to `go install` which takes much longer than a docker pull.

drone.io:
* Make test phase sequential - avoid doubling up on resources requirements.
* Order test phase from fastest to slowest tests - fail fast.
