### PR TITLE
fix(test): Add TextEncoder/TextDecoder polyfill

### DIFF
--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -3,3 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;


### PR DESCRIPTION
These functions are missing in jest, but supported
by default by all major browsers.