### PR TITLE
chore: fix golangci-lint github action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,12 +15,15 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.50
+          version: v1.52
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/internal/api/getobject_test.go
+++ b/internal/api/getobject_test.go
@@ -2,9 +2,9 @@ package api_test
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/SebastiaanPasterkamp/dndmachine/internal/api"
@@ -77,7 +77,7 @@ func TestGetObjectHandler(t *testing.T) {
 			if tt.expectedResponse != "" {
 				response := w.Body.String()
 
-				expected, err := ioutil.ReadFile(tt.expectedResponse)
+				expected, err := os.ReadFile(tt.expectedResponse)
 				if err != nil {
 					t.Fatalf("failed to read expected response body: %v", err)
 				}

--- a/internal/api/listobjects_test.go
+++ b/internal/api/listobjects_test.go
@@ -2,9 +2,9 @@ package api_test
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/SebastiaanPasterkamp/dndmachine/internal/api"
@@ -77,7 +77,7 @@ func TestListObjectsHandler(t *testing.T) {
 			if tt.expectedResponse != "" {
 				response := w.Body.String()
 
-				expected, err := ioutil.ReadFile(tt.expectedResponse)
+				expected, err := os.ReadFile(tt.expectedResponse)
 				if err != nil {
 					t.Fatalf("failed to read expected response body: %v", err)
 				}

--- a/internal/api/mount_test.go
+++ b/internal/api/mount_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -100,7 +99,7 @@ func TestMount(t *testing.T) {
 
 			response := w.Body.String()
 
-			expected, err := ioutil.ReadFile(tt.expectedResponse)
+			expected, err := os.ReadFile(tt.expectedResponse)
 			if err != nil {
 				t.Fatalf("failed to read expected response body: %v", err)
 			}

--- a/internal/database/import.go
+++ b/internal/database/import.go
@@ -1,11 +1,11 @@
 package database
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
 	"io"
-	"io/ioutil"
 )
 
 func (i *Instance) Import(fh io.Reader) error {
@@ -37,12 +37,13 @@ func (i *Instance) Import(fh io.Reader) error {
 }
 
 func ImportToDB(db *sql.Tx, fh io.Reader) error {
-	data, err := ioutil.ReadAll(fh)
+	buf := bytes.Buffer{}
+	_, err := io.Copy(&buf, fh)
 	if err != nil {
 		return fmt.Errorf("error while reading sql code to import: %w", err)
 	}
 
-	if _, err = db.Exec(string(data)); err != nil {
+	if _, err = db.Exec(buf.String()); err != nil {
 		return fmt.Errorf("%w: %q", ErrImportFailed, err)
 	}
 

--- a/internal/policy/load.go
+++ b/internal/policy/load.go
@@ -2,7 +2,7 @@ package policy
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -10,7 +10,7 @@ import (
 )
 
 func loadDir(dir string) (*ast.Compiler, error) {
-	rules, err := ioutil.ReadDir(dir)
+	rules, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read rules directory %q: %w", dir, err)
 	}
@@ -21,7 +21,7 @@ func loadDir(dir string) (*ast.Compiler, error) {
 			continue
 		}
 
-		data, err := ioutil.ReadFile(path.Join(dir, rule.Name()))
+		data, err := os.ReadFile(path.Join(dir, rule.Name()))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read rule from file %q: %w",
 				rule.Name(), err)

--- a/internal/storage/schemas.go
+++ b/internal/storage/schemas.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -170,7 +169,7 @@ func initialize(db *sql.Tx) error {
 func ListSchemaDir(dir string) ([]*SchemaChange, error) {
 	schemas := []*SchemaChange{}
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return schemas, fmt.Errorf("failed to read dir %q: %w", dir, err)
 	}


### PR DESCRIPTION
CI:
* add setup step for go 1.20
* bump golangci-lint version from 1.50 to 1.52

Chore:
* replace `ioutil.ReadDir` with `os.ReadDir`
* replace `ioutil.ReadFile` with `os.ReadFile`
* replace `ioutil.ReadAll` with `io.Copy` into `bytes.Buffer{}`
