### PR TITLE
ci: switch to cromrots/opa instead of 'go install ...opa'

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,11 +9,10 @@ platform:
 
 steps:
   - name: rego:test
-    image: golang:1.18-stretch
+    image: cromrots/opa:0.52
     commands:
-      - go install github.com/open-policy-agent/opa@v0.38.0
-      - opa test -v internal/policy/rego/
-      - opa test -v internal/policy/testdata/
+      - /opa test -v internal/policy/rego/
+      - /opa test -v internal/policy/testdata/
 
   - name: golang:test
     image: golang:1.18-stretch
@@ -141,6 +140,6 @@ steps:
         **Message:** {{commit.message}}
 ---
 kind: signature
-hmac: 67aa3f537263fd7982d34a7a078b748afa96a52014e410c22cc513420fd8589d
+hmac: c5434d9035889a2983467f02411c2355fd385f4f1a91a982983084952955a1d0
 
 ...


### PR DESCRIPTION
Using the images from the https://github.com/SebastiaanPasterkamp/opa-docker repository